### PR TITLE
fixing str-based emission for aget and selector

### DIFF
--- a/src/gamma/emit/operator.cljs
+++ b/src/gamma/emit/operator.cljs
@@ -32,9 +32,8 @@
 
 
 (defmethod emit :aget [db x]
-  (str (emit (first (body x))) "[" (emit (second (body x))) "]"))
+  [:group (emit (db (first (body x)))) "[" (emit (db (second (body x)))) "]"])
 
 
 (defmethod emit :selector [db x]
-  (str (emit (first (body x))) "." (name (second (body x)))))
-
+  [:group (emit (db (first (body x)))) "." (name (second (body x)))])


### PR DESCRIPTION
aget and selector were acting weird, think I fixed them by using fipp-style formatting rather than str