### PR TITLE
add namespace to build-standard-function-term

### DIFF
--- a/src/gamma/api.clj
+++ b/src/gamma/api.clj
@@ -106,7 +106,7 @@
 
 (defn define-standard-function [[n specs]]
   `(defn ~(symbol (name n)) [& body#]
-     (build-standard-function-term ~n ~specs body#)))
+     (gamma.api/build-standard-function-term ~n ~specs body#)))
 
 (defn gen-constructor [tag]
   `(defn ~(symbol (name tag)) [& body#]


### PR DESCRIPTION
I have a project where I use gamma.api from within an eval call in clojurescript.  After some debug and explanation from Mike Fikes @mfikes on twitter (see https://twitter.com/mfikes/status/758314635154059264), it seems that I need this PR merged to use gamma.

Without the explicit gamma.api namespace, when build-standard-function-term is used from within an eval, the current namespace will be gamma.api$macros and the function does not exist in that namespace, so it fails.  Credit goes to Mike for figuring this out.

[I don't have a good explanation for why this works in the default case, though.]