### PR TITLE
Nested assignments

### DIFF
--- a/src/gamma/compiler/insert_assignments.cljs
+++ b/src/gamma/compiler/insert_assignments.cljs
@@ -47,7 +47,7 @@
         :block
         [db
          [(in-path [:body (- (count (:body e)) 1)] (insert-assignments-sub target-id))
-          ;(insert-assignments)
+          (insert-assignments)
           ]]
         ;:set [db nil]
 

--- a/src/gamma/test/runner.cljs
+++ b/src/gamma/test/runner.cljs
@@ -1,6 +1,8 @@
 (ns gamma.test.runner
-  (:require [gamma.test.constructors]))
+  (:require [gamma.test.constructors]
+            [gamma.test.compiler]))
 
 (enable-console-print!)
 
 (cljs.test/run-tests 'gamma.test.constructors)
+(cljs.test/run-tests 'gamma.test.compiler)

--- a/test/gamma/test/compiler.cljs
+++ b/test/gamma/test/compiler.cljs
@@ -1,0 +1,24 @@
+(ns gamma.test.compiler
+  (:require [cljs.test]
+            [gamma.api :as g]
+            [gamma.compiler.core :refer [compile]]
+            [gamma.tools :refer [glsl-string]]
+            [clojure.string :as str])
+  (:require-macros [cljs.test :refer [is deftest testing]]))
+
+(enable-console-print!)
+
+(defn ->glsl [x]
+  (clojure.string/replace
+    (glsl-string x)
+    #"\s" ""))
+
+(defn mush-vars [glsl]
+  (str/replace glsl #"v[0-9]+" "v%"))
+
+(deftest
+  nested-assignments
+  (let [e (g/* 1.0 1.0)
+        ee (g/block (g/set (g/gl-position) (g/if true (g/+ e e) 3.0)))]
+    (is (= "if(true){(v%=(1.0*1.0));(v%=(v%+v%));}else{(v%=3.0);}(gl_Position=v%);"
+           (mush-vars (->glsl ee))))))


### PR DESCRIPTION
Fixes #36 

Here's a one-character fix (after hours of pain and suffering!)... making `insert-assignments` recurse into blocks. Or was there a reason that was commented out?

I'm not sure if this is fully general, to recurse only into blocks, or if it should walk everything (by mapping over `:body`). Still hazy about how this all works.

Another approach which could also fix my case would be to lift all the assignments to the top level, instead of a local block. I think the downside there is potential inefficiency in case conditional calculations are not used.

I also added a basic test, just covers this one case so far.
